### PR TITLE
Add examples inside comments in issue template

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,5 +1,19 @@
-### Subject of the Issue
-What is the issue about? Link to user story if applicable. 
+<!--It is not necessary to remove the comments as they do not appear in the issue description.-->
 
-### Additional Information
-Add information as necessary. 
+<!--
+Checklist before you create PR:
+- Add matching labels (Priority and Type labels)
+- If it is a user story, then use another format below. Look at issue #6
+- Else, link to user story if applicable
+-->
+
+## Subject of the Issue
+<!--What is the issue about? Link to user story if applicable with #{id}.-->
+
+## Additional Information
+<!--
+Suggestion:
+- Expected and current behaviour
+- How to reproduce issue in a bullet point list
+- Screenshots
+-->

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,7 +1,7 @@
 <!--It is not necessary to remove the comments as they do not appear in the issue description.-->
 
 <!--
-Checklist before you create PR:
+Checklist before you create issue:
 - Add matching labels (Priority and Type labels)
 - If it is a user story, then use another format below. Look at issue #6
 - Else, link to user story if applicable


### PR DESCRIPTION
### Purpose
To remind collaborators to provide more information to issues.

### Approach
Add more information inside comments as it then defaults to not displayed.

### Checklist
- [x] The files and code follows the conventions
