### PR TITLE
Render HTML in utext in news article

### DIFF
--- a/code/src/main/resources/site/parts/news-element/news-element.html
+++ b/code/src/main/resources/site/parts/news-element/news-element.html
@@ -3,5 +3,5 @@
     <p class="preface" data-th-text="${tags}"></p>
     <p class="preface" data-th-text="${caption}"></p>
     <p class="preface" data-th-text="${preface}"></p>
-    <p class="preface" data-th-text="${body}"></p>
+    <p class="preface" data-th-utext="${body}"></p>
 </div>


### PR DESCRIPTION
<!--It is not necessary to remove the comments as they do not appear in the PR.-->

<!--
Checklist before you create PR:
- Link to issue it fixes in the Purpose section
- Add someone for review
- Add matching labels (Priority and Type labels)
- Not ready to merge yet? Add the "Status: Work In Progress" label
-->

## Purpose
Make `<p>text</p>` render to `text` in news articles.

## Approach / Description of changes
Add `u` to `text` in the HTML.

## Code Checklist
- [x] The code follows our code conventions
- [ ] I have added tests for my code
- [ ] I have added documentation for my code
