### PR TITLE
Add the ability for news-element part to show the main image

### DIFF
--- a/code/src/main/resources/site/content-types/news-element/news-element.xml
+++ b/code/src/main/resources/site/content-types/news-element/news-element.xml
@@ -4,7 +4,7 @@
     <form>
 
         <!--
-        Fin ut hvordan man legger til forfattere
+        Finn ut hvordan man legger til forfattere
         <input name="authors" type="ContentSelector">
             <label>Forfatter(e)</label>
             <help-text>Legg til forfattere fra drop down menyen</help-text>

--- a/code/src/main/resources/site/parts/news-element/news-element.es6
+++ b/code/src/main/resources/site/parts/news-element/news-element.es6
@@ -17,6 +17,10 @@ exports.get = () => {
   const newsElementBody = portal.processHtml({
     value: newsElementContent.data.body,
   });
+  const newsElementImage = portal.imageUrl({
+    id: newsElementContent.data.image,
+    scale: 'block(250, 250)',
+  });
 
   const model = {
     name: newsElementName,
@@ -24,6 +28,7 @@ exports.get = () => {
     caption: newsElementCaption,
     preface: newsElementPreface,
     body: newsElementBody,
+    image: newsElementImage,
   };
 
   return {

--- a/code/src/main/resources/site/parts/news-element/news-element.html
+++ b/code/src/main/resources/site/parts/news-element/news-element.html
@@ -4,4 +4,5 @@
     <p class="preface" data-th-text="${caption}"></p>
     <p class="preface" data-th-text="${preface}"></p>
     <p class="preface" data-th-utext="${body}"></p>
+    <img data-th-src="${image}"/>
 </div>


### PR DESCRIPTION
<!--It is not necessary to remove the comments as they do not appear in the PR.-->

<!--
Checklist before you create PR:
- Link to issue it fixes in the Purpose section
- Add someone for review
- Add matching labels (Priority and Type labels)
- Not ready to merge yet? Add the "Status: Work In Progress" label
-->

## Purpose
news-element part did not fetch the image, now it does.

## Code Checklist
- [x] The code follows our code conventions
- [ ] I have added tests for my code
- [ ] I have added documentation for my code

## Learning
<!--Link to libraries, addons and sources of information used to solve the problem.-->
