### PR TITLE
Enonic routing

### DIFF
--- a/code/build.gradle
+++ b/code/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     //include "com.enonic.xp:lib-i18n:${xpVersion}"
     //include "com.enonic.xp:lib-auth:${xpVersion}"
     //include "com.enonic.xp:lib-cache:${xpVersion}"
-    //include "com.enonic.lib:menu:1.2.0"
+    include "com.enonic.lib:menu:2.0.1"
     include "com.enonic.lib:util:1.1.2"
     testCompile "junit:junit:4.12"
 }

--- a/code/build.gradle
+++ b/code/build.gradle
@@ -24,7 +24,6 @@ dependencies {
     include "com.enonic.xp:lib-thymeleaf:${xpVersion}"
     include "com.enonic.xp:lib-io:${xpVersion}"
     include "com.enonic.xp:lib-auth:${xpVersion}"
-    include "com.enonic.lib:lib-router:1.0.1"
     include "com.enonic.lib:lib-guillotine:1.0.0"
     //include "com.enonic.xp:lib-http-client:${xpVersion}"
     //include "com.enonic.xp:lib-mail:${xpVersion}"

--- a/code/src/main/resources/site/pages/default/default.es6
+++ b/code/src/main/resources/site/pages/default/default.es6
@@ -1,5 +1,6 @@
 import * as portal from '/lib/xp/portal';
 import * as thymeleaf from '/lib/xp/thymeleaf';
+import * as menu from '/lib/enonic/menu';
 
 const views = {
   defaultview: resolve('default.html'),
@@ -22,7 +23,9 @@ exports.get = () => {
     scale: 'block(800, 200)',
   });
 
-  const header = thymeleaf.render(views.header);
+  const header = thymeleaf.render(views.header, {
+    menuItems: menu.getMenuTree(1),
+  });
   const footer = thymeleaf.render(views.footer);
 
   // Prepare the model that will be passed to the view

--- a/code/src/main/resources/site/pages/default/header.html
+++ b/code/src/main/resources/site/pages/default/header.html
@@ -22,4 +22,12 @@
       </div>
     </a>
   </div>
+  <ul class="list">
+    <li class="item" data-th-each="menuItem : ${menuItems}">
+        <a class="link"
+           data-th-classappend="${menuItem.path == currentPath ? 'active' : ''}"
+           data-th-href="${portal.pageUrl({'_path=' + menuItem.path})}"
+           data-th-text="${menuItem.menuName} ?: ${menuItem.displayName}">Sidetittel</a>
+    </li>
+  </ul>
 </div>

--- a/code/src/main/resources/site/parts/news-element/news-element.es6
+++ b/code/src/main/resources/site/parts/news-element/news-element.es6
@@ -1,34 +1,28 @@
 import * as portal from '/lib/xp/portal';
 import * as thymeleaf from '/lib/xp/thymeleaf';
-import * as content from '/lib/xp/content';
 
 exports.get = () => {
   const view = resolve('news-element.html');
 
-  const component = portal.getComponent();
-  const newsElement = component.config['news-element'];
+  const content = portal.getContent();
 
-  const newsElementContent = content.get({ key: newsElement });
-  // Her hentes ting ut
-  const newsElementName = newsElementContent.displayName;
-  const newsElementTags = newsElementContent.data.tags;
-  const newsElementCaption = newsElementContent.data.caption;
-  const newsElementPreface = newsElementContent.data.preface;
-  const newsElementBody = portal.processHtml({
-    value: newsElementContent.data.body,
+  const name = content.displayName;
+  const { data: { tags, caption, preface } } = content;
+  const body = portal.processHtml({
+    value: content.data.body,
   });
-  const newsElementImage = portal.imageUrl({
-    id: newsElementContent.data.image,
+  const image = portal.imageUrl({
+    id: content.data.image,
     scale: 'block(250, 250)',
   });
 
   const model = {
-    name: newsElementName,
-    tags: newsElementTags,
-    caption: newsElementCaption,
-    preface: newsElementPreface,
-    body: newsElementBody,
-    image: newsElementImage,
+    name,
+    tags,
+    caption,
+    preface,
+    body,
+    image,
   };
 
   return {

--- a/code/src/main/resources/site/parts/news-element/news-element.xml
+++ b/code/src/main/resources/site/parts/news-element/news-element.xml
@@ -1,12 +1,5 @@
 <part>
     <display-name>Nyhetsartikkel</display-name>
     <config>
-        <input type="ContentSelector" name="news-element">
-            <label>news-element</label>
-            <occurrences minimum="1" maximum="1"/>
-            <config>
-                <allow-content-type>news-element</allow-content-type>
-            </config>
-        </input>
     </config>
 </part>

--- a/code/src/main/resources/site/parts/news-list/news-list.es6
+++ b/code/src/main/resources/site/parts/news-list/news-list.es6
@@ -17,13 +17,8 @@ exports.get = () => {
   }
 
   newsElementContentKeys.forEach(newsElementKey => {
-    const newsElementContent = content.get({ key: newsElementKey });
-    // Her hentes ting ut
-    const newsElementName = newsElementContent.displayName;
-
-    newsElements.push({
-      name: newsElementName,
-    });
+    const { displayName, _id, _path } = content.get({ key: newsElementKey });
+    newsElements.push({ displayName, _id, _path });
   });
 
   const model = {

--- a/code/src/main/resources/site/parts/news-list/news-list.html
+++ b/code/src/main/resources/site/parts/news-list/news-list.html
@@ -5,7 +5,9 @@
     </div>
     <div th:if="${newsElements}">
         <div data-th-each="newsElement : ${newsElements}">
-            <p data-th-text="${newsElement.name}"></p>
+            <a
+                data-th-href="${portal.pageUrl({'_path=' + newsElement._path})}"
+                data-th-text="${newsElement.displayName}"></a>
         </div>
     </div>
 </div>

--- a/code/src/main/resources/site/site.xml
+++ b/code/src/main/resources/site/site.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
   <config/>
+  <x-data mixin="menu-item"/>
 </site>


### PR DESCRIPTION
<!--It is not necessary to remove the comments as they do not appear in the PR.-->

<!--
Checklist before you create PR:
- Link to issue it fixes in the Purpose section
- Add someone for review
- Add matching labels (Priority and Type labels)
- Not ready to merge yet? Add the "Status: Work In Progress" label
-->

## Purpose
Make it possible for users to add routes themselves.
Fix #67 

## Approach / Description of changes
Enonic XP admins can now just select what routes that should appear in the menu. Articles will also render based on the url.

Now the admin just needs to config the site to get the system up and working:
![image](https://user-images.githubusercontent.com/8504538/38621319-ed9b0202-3da0-11e8-86ee-73a06bc33c0b.png)

## Code Checklist
- [x] The code follows our code conventions
- [ ] I have added tests for my code
- [ ] I have added documentation for my code
