### PR TITLE
Make subtitle for news list optional

### DIFF
--- a/code/src/main/resources/site/parts/news-list/news-list.xml
+++ b/code/src/main/resources/site/parts/news-list/news-list.xml
@@ -7,7 +7,7 @@
     </input>
     <input type="TextLine" name="subtitle">
       <label>Undertittel</label>
-      <occurrences minimum="1" maximum="1"/>
+      <occurrences minimum="0" maximum="1"/>
     </input>
     <option-set name="articleListOptions">
       <label>Artikkelvisning</label>


### PR DESCRIPTION
<!--It is not necessary to remove the comments as they do not appear in the PR.-->

<!--
Checklist before you create PR:
- Link to issue it fixes in the Purpose section
- Add someone for review
- Add matching labels (Priority and Type labels)
- Not ready to merge yet? Add the "Status: Work In Progress" label
-->

## Purpose
The subtitle should not be marked as required in the news article list.

## Approach / Description of changes
Before:
![image](https://user-images.githubusercontent.com/8504538/39960091-6a4f7628-561c-11e8-9282-184fd98f5c5a.png)

Now:
![image](https://user-images.githubusercontent.com/8504538/39960082-36fda736-561c-11e8-97ab-dd8950d5be9c.png)

## Code Checklist
- [x] The code follows our code conventions
- [ ] I have added tests for my code
- [ ] I have added documentation for my code
