### PR TITLE
Add WSL option to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Just use your terminal and distro of choice.
 [iTerm2](https://www.iterm2.com/) is recommended for Mac, but the default terminal works just as fine for running this project.
 
 ## Windows
-It is recommended to install a unix-like shell for Windows, e.g. [Cygwin](https://cygwin.com/install.html) or [Babun](http://babun.github.io/) (Babun is pre-configured Cygwin with additional packages).
+It is recommended to install a unix-like shell for Windows, e.g. [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10) (official from Microsoft), [Cygwin](https://cygwin.com/install.html) or [Babun](http://babun.github.io/) (Babun is pre-configured Cygwin with additional packages).
 
 # Setup
 - Start Docker


### PR DESCRIPTION
Added link to installation of Windows Subsystem fro Linux (WSL) to README.md

WSL is an alternative to Cygwin/Babun. It is make officially by Microsoft, and supports more distribution specific features, such as `apt/apt-get` for the Ubuntu and Debian versions.