### PR TITLE
Add HTTPS to leaflet CSS CDN

### DIFF
--- a/code/src/main/resources/site/parts/map/map.es6
+++ b/code/src/main/resources/site/parts/map/map.es6
@@ -9,7 +9,7 @@ exports.get = request => {
   return {
     body: thymeleaf.render(view, { request, content, component }),
     pageContributions: {
-      headEnd: ['<link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/leaflet/1.3.1/leaflet.css" />'],
+      headEnd: ['<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.3.1/leaflet.css" />'],
     },
   };
 };


### PR DESCRIPTION
<!--It is not necessary to remove the comments as they do not appear in the PR.-->

<!--
Checklist before you create PR:
- Link to issue it fixes in the Purpose section
- Add someone for review
- Add matching labels (Priority and Type labels)
- Not ready to merge yet? Add the "Status: Work In Progress" label
-->

## Purpose
HTTPS requires all resources to be HTTPS. Leaflet was included with HTTP and caused failure.